### PR TITLE
Do not assume admin privileges on keystone

### DIFF
--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -31,6 +31,9 @@ import six
 from caso import keystone_client
 from caso import loading
 
+from keystoneauth1.exceptions.catalog import EmptyCatalog
+from keystoneauth1.exceptions.http import Forbidden
+
 cli_opts = [
     cfg.ListOpt(
         "projects",
@@ -119,12 +122,20 @@ class Manager(object):
     def projects(self):
         """Get list of configured projects."""
         projects = CONF.projects
-        aux = [i.id for i in self.keystone.projects.list(tags=CONF.caso_tag)]
+        aux = []
+        try:
+            aux = [i.id for i in self.keystone.projects.list(tags=CONF.caso_tag)]
+        except Forbidden as e:
+            LOG.warning(f"Unable to get projects from Keystone, ignoring - {e}")
         return set(projects + aux)
 
-    def _get_keystone_client(self):
+    def _get_keystone_client(self, project=None, system_scope="all"):
         """Get a Keystone Client to get the projects that we will use."""
-        client = keystone_client.get_client(CONF, system_scope="all")
+        if project:
+            system_scope = None
+        client = keystone_client.get_client(CONF,
+                                            project=project,
+                                            system_scope=system_scope)
         return client
 
     def get_lastrun(self, project):
@@ -195,7 +206,14 @@ class Manager(object):
 
     def get_project_vo(self, project_id):
         """Get the VO where the project should be mapped."""
-        project = self.keystone.projects.get(project_id)
+        try:
+            project = self.keystone.projects.get(project_id)
+        except (EmptyCatalog, Forbidden):
+            # we may need scoping here, retrying
+            LOG.warning(f"Scoping the keystone client to the current project {project_id}")
+            self.keystone = self._get_keystone_client(project_id)
+            project = self.keystone.projects.get(project_id)
+
         project.get()
         vo = project.to_dict().get(CONF.vo_property, None)
         if vo is None:

--- a/caso/extract/openstack/base.py
+++ b/caso/extract/openstack/base.py
@@ -92,7 +92,7 @@ class BaseOpenStackExtractor(base.BaseProjectExtractor):
 
     def _get_keystone_client(self):
         """Get a Keystone Client for the configured project in the object."""
-        client = keystone_client.get_client(CONF, system_scope="all")
+        client = keystone_client.get_client(CONF, project=self.project, system_scope="all")
         return client
 
     def _get_cinder_client(self):

--- a/caso/record.py
+++ b/caso/record.py
@@ -79,7 +79,7 @@ class CloudRecord(_BaseRecord):
 
     image_id: typing.Optional[str]
 
-    public_ip_count = 0
+    public_ip_count: int = pydantic.Field(0)
     cpu_count: int
     memory: int
     disk: int


### PR DESCRIPTION
# Description

Avoid issues when running cASO with a low privileges account that cannot
list all projects and scope the tokens to the projects that are to be
accounted. This allows to run cASO and generate records for non-admin
users.

Fixes #124

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- [X] Test `caso-extract` using `v3oidcaccesstoken` authentication with an EGI Check-in access token in 2 projects at IFCA-LCG2. Configuration:
  ```
  [DEFAULT]
  spooldir = var/spool/caso
  site_name = IFCA-LCG2
  projects = 999f045cb1ff4684a15ebb338af69460, 5eb8959a799240a98f4f303f5fbd80be
  [accelerator]
  [benchmark]
  [keystone_auth]
  auth_type = v3oidcaccesstoken
  auth_url = https://api.cloud.ifca.es:5000/v3
  project_id = 999f045cb1ff4684a15ebb338af69460
  identity_provider = egi.eu
  protocol = openid
  access_token = XXX-redacted
  [logstash]
  [sample_remote_file_source]
  [ssm]
  ```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
