### PR TITLE
New Kafka module

### DIFF
--- a/caso/messenger/kafka.py
+++ b/caso/messenger/kafka.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2014 Spanish National Research Council (CSIC)
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Module containing a Logstask cASO messenger."""
+
+import socket
+
+from oslo_config import cfg
+from oslo_log import log
+import six
+
+from caso import exception
+import caso.messenger
+#add json lib
+import json
+#add datetime lib
+import datetime
+#add confluent lib
+from confluent_kafka import Producer, Consumer
+
+opts = [
+    cfg.StrOpt("brokers", default="localhost:9092", help="Kafka host to send records to."),
+    cfg.StrOpt("topic", default="caso", help="Kafka server topic."),
+    cfg.StrOpt("serviceName", default="caso", help="Kafka server service name."),
+    cfg.StrOpt("username", default="username", help="Kafka server username."),
+    cfg.StrOpt("password", default="password", help="Kafka server password."),
+]
+
+CONF = cfg.CONF
+CONF.register_opts(opts, group="kafka")
+
+LOG = log.getLogger(__name__)
+
+
+class KafkaMessenger(caso.messenger.BaseMessenger):
+    """Format and send records to a kafka host."""
+
+    def __init__(self, brokers=CONF.kafka.brokers, topic=CONF.kafka.topic, serviceName=CONF.kafka.serviceName, username=CONF.kafka.username, password=CONF.kafka.password):
+        """Get a logstash messenger for a given host and port."""
+        super(KafkaMessenger, self).__init__()
+        self.brokers = CONF.kafka.brokers
+        self.topic = CONF.kafka.topic
+        self.serviceName = CONF.kafka.serviceName
+        self.username = CONF.kafka.username
+        self.password = CONF.kafka.password
+
+
+    def delivery_report(self, err, msg):
+        """ Called once for each message produced to indicate delivery result.
+        Triggered by poll() or flush(). """
+        if err is not None:
+            print('Message delivery failed: {}'.format(err))
+        else:
+            print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+
+
+    def push(self, records):
+
+        # NOTE(acostantini): code for the serialization and push of the
+        # records in logstash. JSON format to be used and encoding UTF-8
+        """Serialization of records to be sent to logstash via kafka"""
+        if not records:
+            return
+
+        #Actual timestamp to be added on each record       
+        cdt = datetime.datetime.now()
+        ct = int(datetime.datetime.now().timestamp())
+
+        # Producer with SSL support
+        conf = {
+            'bootstrap.servers': self.brokers,
+            'ssl.ca.location': "/var/private/ssl/accounting/ca.crt",
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.kerberos.service.name': self.serviceName,
+            'sasl.username': self.username,
+            'sasl.password': self.password
+
+        # We can tune as args batch_size and linger_ms
+        producer = Producer(**conf)
+
+
+        """Push records to logstash using tcp."""
+        for record in records:
+        #serialization of record
+              rec=record.logstash_message()
+        #cASO timestamp added to each record
+              rec['caso-timestamp']=ct
+        
+        #Send the record to Kafka
+
+              try:
+                  producer.poll(0)
+                  producer.produce(self.topic, value=json.dumps(rec).encode('utf-8'),
+                            callback=self.delivery_report)
+  
+              except ValueError as err:
+                  print("This alert can't be read" % (err))
+
+        producer.flush()
+

--- a/caso/messenger/kafka.py
+++ b/caso/messenger/kafka.py
@@ -97,7 +97,7 @@ class KafkaMessenger(caso.messenger.BaseMessenger):
         """Push records to be serialized using logstash_message definition."""
         for record in records:
         #serialization of record
-              rec=record.logstash_message()
+              rec=record.serialization_message()
         #cASO timestamp added to each record
               rec['caso-timestamp']=ct
         

--- a/caso/messenger/kafka.py
+++ b/caso/messenger/kafka.py
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""Module containing a Logstask cASO messenger."""
+"""Module containing a Kafka cASO messenger."""
 
 import socket
 
@@ -49,7 +49,7 @@ class KafkaMessenger(caso.messenger.BaseMessenger):
     """Format and send records to a kafka host."""
 
     def __init__(self, brokers=CONF.kafka.brokers, topic=CONF.kafka.topic, serviceName=CONF.kafka.serviceName, username=CONF.kafka.username, password=CONF.kafka.password):
-        """Get a logstash messenger for a given host and port."""
+        """Get a kafka messenger for a given host and port."""
         super(KafkaMessenger, self).__init__()
         self.brokers = CONF.kafka.brokers
         self.topic = CONF.kafka.topic
@@ -71,7 +71,7 @@ class KafkaMessenger(caso.messenger.BaseMessenger):
     def push(self, records):
 
         # NOTE(acostantini): code for the serialization and push of the
-        # records in logstash. JSON format to be used and encoding UTF-8
+        # records in logstash via kafka. JSON format to be used and encoding UTF-8
         """Serialization of records to be sent to logstash via kafka"""
         if not records:
             return
@@ -90,11 +90,11 @@ class KafkaMessenger(caso.messenger.BaseMessenger):
             'sasl.username': self.username,
             'sasl.password': self.password
 
-        # We can tune as args batch_size and linger_ms
+        # Producer
         producer = Producer(**conf)
 
 
-        """Push records to logstash using tcp."""
+        """Push records to be serialized using logstash_message definition."""
         for record in records:
         #serialization of record
               rec=record.logstash_message()

--- a/caso/opts.py
+++ b/caso/opts.py
@@ -25,6 +25,7 @@ import caso.keystone_client
 import caso.manager
 import caso.messenger.logstash
 import caso.messenger.ssm
+import caso.messenger.kafka
 
 
 def list_opts():
@@ -43,5 +44,6 @@ def list_opts():
         ("benchmark", caso.extract.openstack.nova.benchmark_opts),
         ("keystone_auth", caso.keystone_client.opts),
         ("logstash", caso.messenger.logstash.opts),
+        ("kafka", caso.messenger.kafka.opts),
         ("ssm", caso.messenger.ssm.opts),
     ]

--- a/caso/record.py
+++ b/caso/record.py
@@ -48,7 +48,21 @@ class _BaseRecord(pydantic.BaseModel, abc.ABC):
         """Render record as the expected SSM message."""
         raise NotImplementedError("Method not implemented")
 
-
+    def serialization_message(self):
+        """Render record as the expected logstash message."""
+        opts = {
+            "by_alias": True,
+            "exclude_none": True,
+        }
+        # NOTE(acostatnini): part related to the definition of the logstash message to be
+        # serialized before to send data
+        # NOTE(aloga): do not iter over the dictionary returned by record.dict() as this
+        # is just a dictionary representation of the object, where no serialization is
+        # done. In order to get objects correctly serialized we need to convert to JSON,
+        # then reload the model
+        serialized_record = json.loads(self.json(**opts))
+        return serialized_record
+        
 class _ValidCloudStatus(str, enum.Enum):
     started = "started"
     completed = "completed"

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -206,7 +206,7 @@ messenger. Available options:
 ----------------------
 
 Options defined here configure the `kafka <https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/kafka/>`_
-messenger. Mandatory options:
+messenger:
 
 * ``brokers`` (default: ``localhost:9092``), endpoint of Kafka server. Port must be provided for each endpoint.
 * ``topic`` (default: ``caso``), Kafka topic.

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -201,6 +201,20 @@ messenger. Available options:
 * ``host`` (default: ``localhost``), host of Logstash server.
 * ``port`` (default: ``5000``), Logstash server port.
 
+``[kafka]`` section
+----------------------
+
+Options defined here configure the `kafka <https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/kafka/>`_
+messenger. Mandatory options:
+
+* ``brokers`` (default: ``localhost:9092``), host of Kafka server. Port must be provided.
+* ``topic`` (default: ``caso``), Kafka topic.
+* ``serviceName`` (default: ``caso``), Kafka service name.
+* ``username`` (default: ``username``), Kafka username.
+* ``password`` (default: ``password``), Kafka password.
+
+Note: the connection to Kafka is SSL enabled. The CA certificate must be provided under `/var/private/ssl/accounting/ca.crt`
+
 Other cASO configuration options
 --------------------------------
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -144,6 +144,7 @@ of every option. You should check at least the following options:
 
       * ``ssm`` for publishing APEL records.
       * ``logstash`` for publishing to Logstash.
+      * ``kafka`` for publishing to Kafka.
       * ``noop`` do nothing at all.
 
   Note that there might be other messengers available in the system if they are

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -214,7 +214,7 @@ messenger. Mandatory options:
 * ``username`` (default: ``username``), Kafka username.
 * ``password`` (default: ``password``), Kafka password.
 
-Note: the connection to Kafka is SSL enabled. The CA certificate (base64) must be provided under `/var/private/ssl/accounting/ca.crt` of the host running cASO.
+Note: the connection to Kafka is Simple Authentication and Security Layer (SASL) authentication configuration enabled. SSL is also enabled. The CA certificate (base64) must be provided under `/var/private/ssl/accounting/ca.crt` of the host running cASO.
 
 Other cASO configuration options
 --------------------------------

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -206,7 +206,7 @@ messenger. Available options:
 ----------------------
 
 Options defined here configure the `kafka <https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/kafka/>`_
-messenger:
+messenger. based on `confluent-kafka <https://pypi.org/project/confluent-kafka/>`_:
 
 * ``brokers`` (default: ``localhost:9092``), endpoint of Kafka server. Port must be provided for each endpoint.
 * ``topic`` (default: ``caso``), Kafka topic.

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -214,7 +214,7 @@ messenger. Mandatory options:
 * ``username`` (default: ``username``), Kafka username.
 * ``password`` (default: ``password``), Kafka password.
 
-Note: the connection to Kafka is SSL enabled. The CA certificate must be provided under `/var/private/ssl/accounting/ca.crt`
+Note: the connection to Kafka is SSL enabled. The CA certificate (base64) must be provided under `/var/private/ssl/accounting/ca.crt` of the host running cASO.
 
 Other cASO configuration options
 --------------------------------

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -207,7 +207,7 @@ messenger. Available options:
 Options defined here configure the `kafka <https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/kafka/>`_
 messenger. Mandatory options:
 
-* ``brokers`` (default: ``localhost:9092``), host of Kafka server. Port must be provided.
+* ``brokers`` (default: ``localhost:9092``), endpoint of Kafka server. Port must be provided for each endpoint.
 * ``topic`` (default: ``caso``), Kafka topic.
 * ``serviceName`` (default: ``caso``), Kafka service name.
 * ``username`` (default: ``username``), Kafka username.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ python-neutronclient>=6.7.0 # Apache-2.0
 keystoneauth1>=3.4.0 # Apache-2.0
 
 stevedore
-pydantic
+pydantic==1.10.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ python-keystoneclient>=3.0.0 # Apache-2.0
 python-glanceclient>=0.18.0 # Apache-2.0
 python-neutronclient>=6.7.0 # Apache-2.0
 keystoneauth1>=3.4.0 # Apache-2.0
+confluent-kafka>=2.4.0
 
 stevedore
 pydantic==1.10.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ caso.messenger =
     ssm = caso.messenger.ssm:SSMMessenger
     ssmv4 = caso.messenger.ssm:SSMMessengerV04
     logstash = caso.messenger.logstash:LogstashMessenger
+    kafka = caso.messenger.kafka:KafkaMessenger
 
 [build_sphinx]
 source-dir = doc/source


### PR DESCRIPTION
# Description

New module added to send records to Kafka.
The connection to Kafka is Simple Authentication and Security Layer (SASL) authentication configuration enabled. SSL is also enabled. The CA certificate (base64) must be provided under `/var/private/ssl/accounting/ca.crt` of the host running cASO.

Fixes # no issue to fix

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change is provided with a documentation update

# How Has This Been Tested?

Records collected from OpenStack has been sent to kafka consumer. SASL and SSL have been enabled.
Records from Kafka has been sent to Logstash and than to OpenSearch within a testing infrastructure.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
