### PR TITLE
fix: Move system_scope check to the keystone_client

### DIFF
--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -131,8 +131,6 @@ class Manager(object):
 
     def _get_keystone_client(self, project=None, system_scope="all"):
         """Get a Keystone Client to get the projects that we will use."""
-        if project:
-            system_scope = None
         client = keystone_client.get_client(
             CONF, project=project, system_scope=system_scope
         )

--- a/caso/keystone_client.py
+++ b/caso/keystone_client.py
@@ -37,6 +37,8 @@ opts += loading.get_auth_plugin_conf_options("password")
 def get_session(conf, project, system_scope=None):
     """Get an auth session."""
     # First try using project_id
+    if project:
+        system_scope = None
     auth_plugin = loading.load_auth_from_conf_options(
         conf, CFG_GROUP, project_id=project, system_scope=system_scope
     )


### PR DESCRIPTION

# Description

The extractor is trying to use project and system scopes at the same time resulting 
in a Keystone Authentication error:
```
Authentication cannot be scoped to multiple targets. Pick one of: project, domain, trust, system or unscoped
```

Fixes #143

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with a fedcloud production OpenStack with an `accounting` account created as documented 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
